### PR TITLE
fix: HasByAddress should take crypto.Address, like GetByAddress

### DIFF
--- a/tm2/pkg/crypto/keys/keybase.go
+++ b/tm2/pkg/crypto/keys/keybase.go
@@ -170,11 +170,11 @@ func (kb dbKeybase) List() ([]Info, error) {
 
 // HasByNameOrAddress checks if a key with the name or bech32 string address is in the keybase.
 func (kb dbKeybase) HasByNameOrAddress(nameOrBech32 string) (bool, error) {
-	has, err := kb.HasByAddress(nameOrBech32)
+	address, err := crypto.AddressFromBech32(nameOrBech32)
 	if err != nil {
 		return kb.HasByName(nameOrBech32)
 	} else {
-		return has, nil
+		return kb.HasByAddress(address)
 	}
 }
 
@@ -183,13 +183,9 @@ func (kb dbKeybase) HasByName(name string) (bool, error) {
 	return kb.db.Has(infoKey(name)), nil
 }
 
-// HasByAddress checks if a key with the bech32 string address is in the keybase.
-func (kb dbKeybase) HasByAddress(bech32Address string) (bool, error) {
-	addr, err := crypto.AddressFromBech32(bech32Address)
-	if err != nil {
-		return false, err
-	}
-	return kb.db.Has(addrKey(addr)), nil
+// HasByAddress checks if a key with the address is in the keybase.
+func (kb dbKeybase) HasByAddress(address crypto.Address) (bool, error) {
+	return kb.db.Has(addrKey(address)), nil
 }
 
 // Get returns the public information about one key.

--- a/tm2/pkg/crypto/keys/lazy_keybase.go
+++ b/tm2/pkg/crypto/keys/lazy_keybase.go
@@ -57,14 +57,14 @@ func (lkb lazyKeybase) HasByName(name string) (bool, error) {
 	return NewDBKeybase(db).HasByName(name)
 }
 
-func (lkb lazyKeybase) HasByAddress(bech32Address string) (bool, error) {
+func (lkb lazyKeybase) HasByAddress(address crypto.Address) (bool, error) {
 	db, err := db.NewDB(lkb.name, dbBackend, lkb.dir)
 	if err != nil {
 		return false, err
 	}
 	defer db.Close()
 
-	return NewDBKeybase(db).HasByAddress(bech32Address)
+	return NewDBKeybase(db).HasByAddress(address)
 }
 
 func (lkb lazyKeybase) GetByNameOrAddress(nameOrBech32 string) (Info, error) {

--- a/tm2/pkg/crypto/keys/types.go
+++ b/tm2/pkg/crypto/keys/types.go
@@ -15,7 +15,7 @@ type Keybase interface {
 	List() ([]Info, error)
 	HasByNameOrAddress(nameOrBech32 string) (bool, error)
 	HasByName(name string) (bool, error)
-	HasByAddress(bech32Address string) (bool, error)
+	HasByAddress(address crypto.Address) (bool, error)
 	GetByNameOrAddress(nameOrBech32 string) (Info, error)
 	GetByName(name string) (Info, error)
 	GetByAddress(address crypto.Address) (Info, error)


### PR DESCRIPTION
The Keybase method `GetByAddress` [takes a crypto.Address](https://github.com/gnolang/gno/blob/199cd29584d44812a0aec3606bbff37a320c609a/tm2/pkg/crypto/keys/types.go#L18) . PR https://github.com/gnolang/gno/pull/1313 adds more methods, including `HasByAddress`, and we did a cherry-pick into the with-gno-PRs branch. However that version of `HasByAddress` takes a bech32Address. But it should also take a `crypto.Address`. I did a force commit to fix that PR. This PR makes the same changes here in the with-gno-PRs branch.